### PR TITLE
Update documentation for flow: flow-commerce-order-item-mapping

### DIFF
--- a/flows-orders/order-item-mapping-flow.md
+++ b/flows-orders/order-item-mapping-flow.md
@@ -23,38 +23,43 @@ The flow processes incoming order item data and maps it to appropriate Salesforc
 * Flexible pricing logic with support for both unit price and total price models
 * Platform key assignment for external system tracking
 * Quantity and pricing calculations
+* Fee processing logic with configurable skipping
+* Multi-currency support
 
 ## Salesforce Fields
 
 The flow interacts with multiple Salesforce objects and their fields. Below is a comprehensive mapping of all fields utilized:
 
-| Object                  | Field API Name     | Field Type                   | Purpose in Flow                 |
-| ----------------------- | ------------------ | ---------------------------- | ------------------------------- |
-| **OpportunityLineItem** | Id                 | ID                           | Primary record identifier       |
-|                         | OpportunityId      | Master-Detail to Opportunity | Links line item to parent order |
-|                         | PricebookEntryId   | Lookup to PricebookEntry     | Product pricing relationship    |
-|                         | Quantity           | Number                       | Item quantity                   |
-|                         | UnitPrice          | Currency                     | Price per unit                  |
-|                         | TotalPrice         | Currency                     | Total line item price           |
-|                         | Platform\_Key\_\_c | Text                         | External platform identifier    |
-| **Product2**            | Id                 | ID                           | Product record identifier       |
-| **Opportunity**         | Id                 | ID                           | Order record identifier         |
-| **PricebookEntry**      | Id                 | ID                           | Price book entry identifier     |
-|                         | Product2Id         | Lookup to Product2           | Product relationship            |
-|                         | Pricebook2Id       | Lookup to Pricebook2         | Price book relationship         |
+| Object                  | Field API Name                              | Field Type                   | Purpose in Flow                 |
+| ----------------------- | ------------------------------------------- | ---------------------------- | ------------------------------- |
+| **OpportunityLineItem** | Id                                          | ID                           | Primary record identifier       |
+|                         | OpportunityId                               | Master-Detail to Opportunity | Links line item to parent order |
+|                         | PricebookEntryId                            | Lookup to PricebookEntry     | Product pricing relationship    |
+|                         | Quantity                                    | Number                       | Item quantity                   |
+|                         | UnitPrice                                   | Currency                     | Price per unit                  |
+|                         | TotalPrice                                  | Currency                     | Total line item price           |
+|                         | md_npc_pack__Platform_Key__c                | Text                         | External platform identifier    |
+| **Product2**            | Id                                          | ID                           | Product record identifier       |
+| **Opportunity**         | Id                                          | ID                           | Order record identifier         |
+| **PricebookEntry**      | Id                                          | ID                           | Price book entry identifier     |
+|                         | Product2Id                                  | Lookup to Product2           | Product relationship            |
+|                         | Pricebook2Id                                | Lookup to Pricebook2         | Price book relationship         |
 
 ## Input Variables
 
 ### Core Order Item Data
 
-| Variable      | Type                        | Required | Description                                    |
-| ------------- | --------------------------- | -------- | ---------------------------------------------- |
-| `Record`      | OpportunityLineItem SObject | Yes      | The OpportunityLineItem record being processed |
-| `Quantity`    | Number                      | No       | Order item quantity                            |
-| `UnitPrice`   | Currency                    | No       | Price per unit                                 |
-| `Total`       | Currency                    | No       | Total line item price                          |
-| `OrderTotal`  | Currency                    | No       | Total order amount                             |
-| `PlatformKey` | String                      | No       | Unique platform key for record matching        |
+| Variable                                   | Type                        | Required | Description                                                           |
+| ------------------------------------------ | --------------------------- | -------- | --------------------------------------------------------------------- |
+| `Record`                                   | OpportunityLineItem SObject | Yes      | The OpportunityLineItem record being processed                        |
+| `Quantity`                                 | Number                      | No       | Order item quantity                                                   |
+| `UnitPrice`                                | Currency                    | No       | Price per unit                                                        |
+| `Total`                                    | Currency                    | No       | Total line item price                                                 |
+| `OrderTotal`                               | Currency                    | No       | Total order amount                                                    |
+| `PlatformKey`                              | String                      | No       | Unique platform key for record matching                               |
+| `Catalog_Type`                             | String                      | No       | Type of catalog item (e.g., "fee")                                    |
+| `Config_OrderTotalSubtractFeePlatform`     | Boolean                     | No       | Configuration flag to skip fee items (default: false)                |
+| `OrderCurrencyType`                        | String                      | No       | Currency code for the order                                           |
 
 ### Related Records
 
@@ -72,27 +77,42 @@ The flow interacts with multiple Salesforce objects and their fields. Below is a
 
 ## Output Variables
 
-| Variable | Type                        | Description              |
-| -------- | --------------------------- | ------------------------ |
-| `Record` | OpportunityLineItem SObject | Updated line item record |
+| Variable   | Type                        | Description                                    |
+| ---------- | --------------------------- | ---------------------------------------------- |
+| `Record`   | OpportunityLineItem SObject | Updated line item record                       |
+| `Continue` | Boolean                     | Flag indicating whether processing should continue |
+| `Errors`   | String Collection           | Collection of error messages                   |
 
 ## Flow Logic
 
-### 1. Product Relationship Management
+### 1. Fee Processing Logic
+
+**Skip Fees Evaluation:**
+* Checks if `Config_OrderTotalSubtractFeePlatform` is true AND `Catalog_Type` equals "fee"
+* If conditions met, sets `Continue` to true and skips further processing
+* Allows flexible handling of fee items based on configuration
+
+### 2. Product Relationship Management
 
 **Product Assignment:**
 
 * Proceeds only if CatalogRecord (Product2) is provided
 * Ensures proper product relationship for line item creation
 
-**Price Book Entry Lookup:**
+**Currency Processing:**
+* Calls `movedata__CurrencyCodeComponent` apex action to determine/validate currency
+* Processes `OrderCurrencyType` for multi-currency support
 
-* Queries PricebookEntry where Product2Id matches CatalogRecord.Id
-* Filters by StandardPriceBookId for price book consistency
-* Uses `getFirstRecordOnly=true` for single entry retrieval
+**Price Book Entry Processing:**
+
+* Calls `GetPriceBookEntryFlowComponent` apex action with:
+  * CurrencyCode from currency determination
+  * Pricebook2Id (StandardPriceBookId)
+  * Product2Id from CatalogRecord
+* Validates price book entry exists, throws error if not found
 * Sets PricebookEntryId on the line item record
 
-### 2. Opportunity Relationship Processing
+### 3. Opportunity Relationship Processing
 
 **Order Assignment:**
 
@@ -100,7 +120,7 @@ The flow interacts with multiple Salesforce objects and their fields. Below is a
 * Links line item to parent opportunity/order
 * Maintains order-item relationship structure
 
-### 3. Pricing Logic Processing
+### 4. Pricing Logic Processing
 
 The flow handles two distinct pricing models:
 
@@ -129,13 +149,40 @@ The flow handles two distinct pricing models:
 * If neither UnitPrice nor Total is provided, proceeds without price assignment
 * Maintains flexibility for different pricing scenarios
 
-### 4. Platform Key Assignment
+### 5. Platform Key Assignment
 
 **Platform Key Processing:**
 
-* Sets Platform\_Key\_\_c field with provided platform key
+* Sets md_npc_pack__Platform_Key__c field with provided platform key
 * Enables future matching and duplicate detection
 * Supports external system integration
+
+## Action Calls
+
+### Currency Determination
+
+**Action:** `movedata__CurrencyCodeComponent`
+**Type:** Apex
+**Purpose:** Validates and standardizes currency codes for multi-currency processing
+
+**Input Parameters:**
+* CurrencyCode: OrderCurrencyType
+
+**Output Parameters:**
+* CurrencyCode: Updated OrderCurrencyType
+
+### Price Book Entry Retrieval
+
+**Action:** `GetPriceBookEntryFlowComponent`
+**Type:** Apex
+**Purpose:** Retrieves appropriate price book entry with currency support
+
+**Input Parameters:**
+* CurrencyCode: Validated currency code
+* Pricebook2Id: StandardPriceBookId
+* Product2Id: CatalogRecord.Id
+
+**Output:** Price book entry record stored automatically
 
 ## Formulas
 
@@ -161,19 +208,21 @@ The flow handles two distinct pricing models:
 * StandardPriceBookId must reference an active price book
 * Product must have a corresponding PricebookEntry in the standard price book
 * Price book entry must be active for successful lookup
+* Price book entry must support the specified currency
 
-### Lookup Logic
+### Processing Logic
 
-**Query Parameters:**
+**Apex Component Processing:**
 
+* **Currency Validation**: OrderCurrencyType processed through currency component
 * **Product2Id**: Matches CatalogRecord.Id
 * **Pricebook2Id**: Matches StandardPriceBookId
-* **Record Selection**: First matching record only
+* **Currency Support**: Handles multi-currency price book entries
 
 **Error Handling:**
 
-* Uses `assignNullValuesIfNoRecordsFound=false` requiring valid price book entry
-* Flow will fail if no matching price book entry exists
+* Component returns null if no matching price book entry exists
+* Flow adds error message to Errors collection if price book entry not found
 * Ensures data integrity for commerce transactions
 
 ## Error Handling
@@ -181,8 +230,17 @@ The flow handles two distinct pricing models:
 ### Missing Data Scenarios
 
 * **No Product**: Flow skips price book entry lookup and proceeds to opportunity assignment
-* **No Price Book Entry**: Flow fails with error if product provided but no price book entry found
+* **No Price Book Entry**: Flow adds error to Errors collection and continues
 * **No Opportunity**: Flow proceeds without setting OpportunityId
+
+### Error Collection
+
+**Error Messages:**
+* "Could not find a Pricebook Entry." - Added when price book entry lookup fails
+
+**Processing Control:**
+* `Continue` boolean output indicates whether main processing occurred
+* `Errors` collection provides detailed error information for calling processes
 
 ### Data Quality Validation
 
@@ -191,6 +249,8 @@ The flow handles various data quality issues:
 * **Null Values**: Graceful handling of missing optional parameters
 * **Pricing Flexibility**: Supports different pricing models from external platforms
 * **Relationship Integrity**: Ensures proper product-price book relationships
+* **Currency Validation**: Validates currency codes through apex component
+* **Fee Processing**: Configurable skipping of fee items
 
 ## Dependencies
 
@@ -198,10 +258,15 @@ The flow handles various data quality issues:
 
 * Product2 (input record for product relationship)
 * Opportunity (input record for order relationship)
-* PricebookEntry (queried for product pricing)
+* PricebookEntry (retrieved via apex component)
+
+**Apex Components:**
+* `movedata__CurrencyCodeComponent` (currency validation)
+* `GetPriceBookEntryFlowComponent` (price book entry retrieval)
 
 **System Requirements:**
 
 * Active Standard Price Book in organization
-* Valid PricebookEntry records for all products
+* Valid PricebookEntry records for all products with appropriate currencies
 * Appropriate permissions for OpportunityLineItem management
+* Multi-currency enabled if using currency features


### PR DESCRIPTION
Updated documentation to reflect significant flow changes including: new fee skipping logic with `Config_OrderTotalSubtractFeePlatform` and `Catalog_Type` variables, currency handling via `OrderCurrencyType` variable and `Determine_Currency` action, replacement of record lookup with `Get_PriceBook_Entry` apex action, addition of error handling via `Errors` collection and `Continue` boolean output, and expanded input/output variables.