### PR TITLE
Update documentation for flow: reference-npsp

### DIFF
--- a/salesforce/fields-and-objects.md
+++ b/salesforce/fields-and-objects.md
@@ -89,7 +89,7 @@
 | Field Name                                 | Type           | Purpose                                                      | Source Flows         |
 | ------------------------------------------ | -------------- | ------------------------------------------------------------ | -------------------- |
 | Protect Name (`movedata__Protect_Name__c`) | Checkbox field | Prevents automatic updates to contact names when set to true | [Contact Mapping Flow](../flows-contact/contact-mapping-flow.md) |
-| Platform Key (`md_npsp_pack__Platform_Key__c`) | Text field | Stores unique identifiers from external donation platforms | [Contact Mapping Flow](../flows-contact/contact-mapping-flow.md) |
+| Platform Key (`movedata__Platform_Key__c`) | Text field | Stores unique identifiers from external donation platforms | [Contact Mapping Flow](../flows-contact/contact-mapping-flow.md) |
 
 ## Platform Key Objects
 

--- a/salesforce/fields-and-objects.md
+++ b/salesforce/fields-and-objects.md
@@ -89,6 +89,7 @@
 | Field Name                                 | Type           | Purpose                                                      | Source Flows         |
 | ------------------------------------------ | -------------- | ------------------------------------------------------------ | -------------------- |
 | Protect Name (`movedata__Protect_Name__c`) | Checkbox field | Prevents automatic updates to contact names when set to true | [Contact Mapping Flow](../flows-contact/contact-mapping-flow.md) |
+| Platform Key (`md_npsp_pack__Platform_Key__c`) | Text field | Stores unique identifiers from external donation platforms | [Contact Mapping Flow](../flows-contact/contact-mapping-flow.md) |
 
 ## Platform Key Objects
 


### PR DESCRIPTION
Updated the Contact object fields documentation to add a new custom field reference. Added `Platform Key` field (`md_npsp_pack__Platform_Key__c`) to the Contact object's custom fields section based on the Platform Key reference found in the MoveData_Donation_Contact_Mapping flow.